### PR TITLE
Bump faye-websocket to version 0.8.0 to fix issue when running with newe...

### DIFF
--- a/logstream.gemspec
+++ b/logstream.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(libpath) unless $LOAD_PATH.include?(libpath)
 
 Gem::Specification.new do |s|
   s.name = "logstream"
-  s.version = "0.0.4"
+  s.version = "0.0.5"
   s.date = Time.now.strftime("%Y-%m-%d")
 
   s.author = "Barry Jaspan"
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
   s.has_rdoc = false
 
-  s.add_runtime_dependency('faye-websocket', ['~> 0.7.2'])
+  s.add_runtime_dependency('faye-websocket', ['~> 0.8.0'])
   s.add_runtime_dependency('json', ['~> 1.7.7'])
   s.add_runtime_dependency('thor', ['~> 0.19.1'])
 end


### PR DESCRIPTION
...r version of websocket-driver

In issue #12 it was found that when running faye-websocket 0.7.5 with websocket-driver 0.4.0, the initialize function of client.rb in websocket-driver now requires the url to be already set in the socket object, which faye-websocket was doing after creating the Driver class. Version 0.8.0 of faye-websocket fixes this as well as bumping the websocket-driver version to 0.4.0. I have tested this on multiple versions of ruby and it now works correctly.
