### PR TITLE
Replaces QuickCloudAPI with acquia-sdk-ruby

### DIFF
--- a/bin/logstream
+++ b/bin/logstream
@@ -5,38 +5,7 @@ require 'net/https'
 require 'json'
 require 'thor'
 require 'logstream/client'
-
-# @todo: Yeah, this is terrible. Replace it with a real Cloud API gem.
-class QuickCloudAPI
-  class Error < StandardError; end
-
-  def self.get(path, opts = {})
-    confpath = "#{ENV['HOME']}/.acquia/cloudapi.conf"
-    begin
-      json = File.read(confpath)
-      config = JSON.load(json)
-    rescue Errno::ENOENT, JSON::ParserError => e
-      raise Error, "#{confpath} is missing or invalid. Download your Drush aliases from https://accounts.acquia.com/account/security to initialize it."
-    end
-    opts[:endpoint] ||= "https://cloudapi.acquia.com/v1"
-    uri = URI.parse("#{opts[:endpoint]}#{path}.json")
-    http = Net::HTTP.new(uri.host, uri.port)
-    http.use_ssl = true
-    http.ca_file = File.dirname(__FILE__) + "/../etc/ca.pem"
-    http.verify_mode = OpenSSL::SSL::VERIFY_PEER
-    request = Net::HTTP::Get.new(uri.request_uri)
-    request.basic_auth(config['email'], config['key'])
-    response = http.request(request)
-    parsed = JSON.parse(response.body) rescue nil
-    case response.code.to_i
-    when 200
-      raise Error, "Unexpected reply #{response.body}" unless parsed
-      parsed
-    else
-      raise Error, "HTTP #{response.code}: #{response.body}"
-    end
-  end
-end
+require 'acquia_sdk_ruby'
 
 class LogTailorCLI < Thor
   desc "tail SITE ENV", "Stream log information for the specified site environment."
@@ -67,19 +36,21 @@ class LogTailorCLI < Thor
       hides = Hash[options[:hide].map { |h| h.split('=') }.map { |k,v| [k, Regexp.new(v)] }] rescue {}
 
       begin
-        info = QuickCloudAPI.get("/sites/#{site}/envs/#{env}/logstream", { :endpoint => options[:endpoint] })
-        logstream = Logstream::Client.new({ 
-                                            :columns => options[:columns],
-                                            :types => options[:types],
-                                            :shows => shows,
-                                            :hides => hides,
-                                            :no_color => !options[:color],
-                                            :debug => options[:debug],
-                                          })
+        client = Acquia::CloudApi::Client.new
+        info = client.get "sites/#{site}/envs/#{env}/logstream.json"
+
+        logstream = Logstream::Client.new({
+          :columns  => options[:columns],
+          :types    => options[:types],
+          :shows    => shows,
+          :hides    => hides,
+          :no_color => !options[:color],
+          :debug    => options[:debug],
+        })
+
         logstream.run(info['url'], info['msg'])
-      rescue QuickCloudAPI::Error => e
-        puts "Cloud API error: #{e.message}"
-        exit(1)
+      rescue StandardError => e
+        puts "Cloud API Error: #{e.message}"
       end
     end
   end

--- a/logstream.gemspec
+++ b/logstream.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('thor', ['~> 0.19.1'])
   s.add_runtime_dependency('acquia_sdk_ruby', '~> 0.0.2')
 
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.0.0'
 end

--- a/logstream.gemspec
+++ b/logstream.gemspec
@@ -22,8 +22,9 @@ Gem::Specification.new do |s|
   s.has_rdoc = false
 
   s.add_runtime_dependency('faye-websocket', ['~> 0.8.0'])
-  s.add_runtime_dependency('json', ['~> 1.7.7'])
+  s.add_runtime_dependency('json', ['~> 1.8'])
   s.add_runtime_dependency('thor', ['~> 0.19.1'])
+  s.add_runtime_dependency('acquia_sdk_ruby', '~> 0.0.2')
 
   s.required_ruby_version = '>= 1.9.3'
 end


### PR DESCRIPTION
This substitutes in [acquia-sdk-ruby](https://github.com/jacobbednarz/acquia-sdk-ruby) for QuickCloudAPI as it is a more robust and maintainable solution. In the future, the acquia-sdk-ruby will extend to cover the options available via the API (including logstream) as well as some system integrations.

Other minor changes:
- Bumped JSON to be 1.8.
- Minor formatting changes
- Rescuing `StandardError` instead of class specific exception

What are your thoughts on this change?
