### PR TITLE
Allow for versions of json > 1.8.0

### DIFF
--- a/logstream.gemspec
+++ b/logstream.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.has_rdoc = false
 
   s.add_runtime_dependency('faye-websocket', ['~> 0.8.0'])
-  s.add_runtime_dependency('json', ['~> 1.7.7'])
+  s.add_runtime_dependency('json', ['>= 1.7.7'])
   s.add_runtime_dependency('thor', ['~> 0.19.1'])
 
   s.required_ruby_version = '>= 1.9.3'


### PR DESCRIPTION
I tried to install this locally, but compilation on my system failed due to (I think) this: https://github.com/flori/json/issues/229

I tested with my local version of json 1.8.2 and everything seems to work fine.

Here's what I'm running locally (OSX 10.10.3):

````
$ ruby --version
ruby 2.2.1p85 (2015-02-26 revision 49769) [x86_64-darwin14]

$ gem list

*** LOCAL GEMS ***

bigdecimal (1.2.7, 1.2.6)
eventmachine (1.0.7)
faye-websocket (0.8.0)
io-console (0.4.3)
json (1.8.2, 1.8.1)
logstream (0.0.6)
minitest (5.5.1)
power_assert (0.2.3)
psych (2.0.13, 2.0.8)
rake (10.4.2)
rdoc (4.2.0)
test-unit (3.0.9)
thor (0.19.1)
websocket-driver (0.5.3)
websocket-extensions (0.1.2)
````